### PR TITLE
Set package name checking to false

### DIFF
--- a/{{cookiecutter.repo_name}}/.detekt-config.yml
+++ b/{{cookiecutter.repo_name}}/.detekt-config.yml
@@ -331,7 +331,7 @@ naming:
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '(_)?[A-Za-z][A-Za-z0-9]*'
   PackageNaming:
-    active: true
+    active: false
     packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
   TopLevelPropertyNaming:
     active: true


### PR DESCRIPTION
Changed the package name checking to false. Otherwise, detekt complains even if the package name is correct.